### PR TITLE
Change exception tree

### DIFF
--- a/gmopg/__init__.py
+++ b/gmopg/__init__.py
@@ -20,7 +20,10 @@ def make_requests_with_retries():
     return session
 
 
-class ResponseError(Exception):
+class GMOPGException(Exception):
+    pass
+
+class ResponseError(GMOPGException):
 
     def __init__(self, response):
         self.error = self.parse(response.data)
@@ -72,8 +75,6 @@ class BaseAPI(object):
     def _requests(self, method, path, **kwargs):
 
         response = method(self.api_base_url + path, timeout=self.timeout, **kwargs)
-
-        response.raise_for_status()
 
         response = Response(response.text)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='gmopg',
-      version='0.0.3',
+      version='0.0.4',
       description='Python API Client for GMO Payment Gateway',
       license="MIT",
       keywords="gmopg",


### PR DESCRIPTION
Fix #1 

- Stop response.raise_for_status (because, want to raise ResponseException when check `response.ok` )
- Add library base exception: GMOPGException